### PR TITLE
Fix tomato:generate command not working with sqlite and some other DBs.

### DIFF
--- a/src/Console/TomatoGenerator.php
+++ b/src/Console/TomatoGenerator.php
@@ -3,6 +3,7 @@
 namespace TomatoPHP\TomatoPHP\Console;
 
 use Doctrine\DBAL\Schema\Schema;
+use Illuminate\Database\Schema\Builder;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Nwidart\Modules\Facades\Module;
@@ -42,12 +43,9 @@ class TomatoGenerator extends Command
     /**
      * @return void
      */
-    public function handle(): void
+    public function handle(Builder $schema): void
     {
-
-        $tables = collect(\DB::select('SHOW TABLES'))->map(function ($item){
-            return $item->{'Tables_in_'.config('database.connections.mysql.database')};
-        })->toArray();
+        $tables = $schema->getTableListing();
 
         $tableName = $this->argument('table') && $this->argument('table') != "0" ? $this->argument('table') : search(
             label: 'Please input your table name you went to create CRUD?',


### PR DESCRIPTION

`show tables` command works with MySQL but not with some other DBs. So it's wise to use Laravel build in functionality.